### PR TITLE
Master

### DIFF
--- a/cv.c
+++ b/cv.c
@@ -59,8 +59,12 @@
 #include "sizes.h"
 #include "hlist.h"
 
+<<<<<<< Updated upstream
 char *proc_names[] = {"cp", "mv", "dd", "tar", "gzip", "gunzip", "zip", "unzip", "7z", "cat", "grep", "fgrep", "egrep", "cut", "sort", "xz", "md5sum", "md5", "sha1sum", "shasum", "shasum5.16", "shasum5.18", "sha224sum", "sha256sum", "sha384sum", "sha512sum","perl5.16", "perl5.18", "adb", NULL
 };
+=======
+char *proc_names[] = {"cp", "mv", "dd", "tar", "gzip", "gunzip", "zip", "unzip", "cat", "grep", "fgrep", "egrep", "cut", "sort", "xz", "md5sum", "md5", "sha1sum", "shasum", "shasum5.16", "shasum5.18", "sha224sum", "sha256sum", "sha384sum", "sha512sum","perl5.16", "perl5.18", "adb", NULL };
+>>>>>>> Stashed changes
 
 static int proc_specifiq_name_cnt;
 static char **proc_specifiq_name;

--- a/cv.c
+++ b/cv.c
@@ -51,12 +51,12 @@
 #include "sizes.h"
 #include "hlist.h"
 
-char *proc_names[] = {"cp", "mv", "dd", "tar", "gzip", "gunzip", "cat",
-    "grep", "fgrep", "egrep", "cut", "sort", "xz", "md5sum", "sha1sum",
-    "sha224sum", "sha256sum", "sha384sum", "sha512sum", NULL
+char *proc_names[] = {"cp", "mv", "dd", "tar", "gzip", "gunzip", "zip", "unzip", "cat", "grep", "fgrep", "egrep", "cut", "sort", "xz", "md5sum", "md5", "sha1sum", "shasum", "shasum5.16", "shasum5.18", "sha224sum", "sha256sum", "sha384sum", "sha512sum","perl5.16", "perl5.18", "adb", NULL
 };
 
-char *proc_specifiq_name = NULL;
+static int proc_specifiq_name_cnt;
+static char **proc_specifiq_name;
+
 pid_t proc_specifiq_pid = 0;
 signed char flag_quiet = 0;
 signed char flag_debug = 0;
@@ -502,7 +502,9 @@ while(1) {
             break;
 
         case 'c':
-            proc_specifiq_name = strdup(optarg);
+            proc_specifiq_name_cnt++;
+            proc_specifiq_name = realloc(proc_specifiq_name, proc_specifiq_name_cnt * sizeof(proc_specifiq_name[0]));
+            proc_specifiq_name[proc_specifiq_name_cnt - 1] = strdup(optarg);
             break;
 
         case 'p':
@@ -597,10 +599,11 @@ signed char search_all = 1;
 
 pid_count = 0;
 
-if (proc_specifiq_name) {
-    pid_count += find_pids_by_binary_name(proc_specifiq_name,
-                                          pidinfo_list + pid_count,
-                                          MAX_PIDS - pid_count);
+if (proc_specifiq_name_cnt) {
+    for (i = 0; i < proc_specifiq_name_cnt; ++i)
+        pid_count += find_pids_by_binary_name(proc_specifiq_name[i],
+                                              pidinfo_list + pid_count,
+                                              MAX_PIDS - pid_count);
     search_all = 0;
 }
 

--- a/cv.c
+++ b/cv.c
@@ -43,11 +43,11 @@
 # include <sys/proc_info.h>
 # include <libproc.h>
 # include <sys/disk.h>
-#elif __linux
+#elif __linux__
 # include <linux/fs.h>
-#elif __uinx
+#elif __uinx__
 //#include
-#elif __FreeBSD
+#elif __FreeBSD__
 //#include
 #elif _WIN32
 //#include

--- a/cv.c
+++ b/cv.c
@@ -43,15 +43,23 @@
 # include <sys/proc_info.h>
 # include <libproc.h>
 # include <sys/disk.h>
-#else
+#elif __linux
 # include <linux/fs.h>
+#elif __uinx
+//#include
+#elif __FreeBSD
+//#include
+#elif _WIN32
+//#include
+#elif _WIN64
+//#include
 #endif
 
 #include "cv.h"
 #include "sizes.h"
 #include "hlist.h"
 
-char *proc_names[] = {"cp", "mv", "dd", "tar", "gzip", "gunzip", "zip", "unzip", "cat", "grep", "fgrep", "egrep", "cut", "sort", "xz", "md5sum", "md5", "sha1sum", "shasum", "shasum5.16", "shasum5.18", "sha224sum", "sha256sum", "sha384sum", "sha512sum","perl5.16", "perl5.18", "adb", NULL
+char *proc_names[] = {"cp", "mv", "dd", "tar", "gzip", "gunzip", "zip", "unzip", "7z", "cat", "grep", "fgrep", "egrep", "cut", "sort", "xz", "md5sum", "md5", "sha1sum", "shasum", "shasum5.16", "shasum5.18", "sha224sum", "sha256sum", "sha384sum", "sha512sum","perl5.16", "perl5.18", "adb", NULL
 };
 
 static int proc_specifiq_name_cnt;

--- a/cv.c
+++ b/cv.c
@@ -59,12 +59,9 @@
 #include "sizes.h"
 #include "hlist.h"
 
-<<<<<<< Updated upstream
 char *proc_names[] = {"cp", "mv", "dd", "tar", "gzip", "gunzip", "zip", "unzip", "7z", "cat", "grep", "fgrep", "egrep", "cut", "sort", "xz", "md5sum", "md5", "sha1sum", "shasum", "shasum5.16", "shasum5.18", "sha224sum", "sha256sum", "sha384sum", "sha512sum","perl5.16", "perl5.18", "adb", NULL
 };
-=======
-char *proc_names[] = {"cp", "mv", "dd", "tar", "gzip", "gunzip", "zip", "unzip", "cat", "grep", "fgrep", "egrep", "cut", "sort", "xz", "md5sum", "md5", "sha1sum", "shasum", "shasum5.16", "shasum5.18", "sha224sum", "sha256sum", "sha384sum", "sha512sum","perl5.16", "perl5.18", "adb", NULL };
->>>>>>> Stashed changes
+
 
 static int proc_specifiq_name_cnt;
 static char **proc_specifiq_name;


### PR DESCRIPTION
add perl 5.18 in OS X (for shasuam and md5 OS X is using perl 5.18)
